### PR TITLE
Add sales data for Relaxed Kufaika t-shirt

### DIFF
--- a/sales-data.js
+++ b/sales-data.js
@@ -1554,6 +1554,43 @@ export const salesData = {
           }
         }
       ]
+    },
+    {
+      "name": "Футболка Relaxed Kufaika",
+      "months": [
+        {
+          "month": "Липень",
+          "year": 2025,
+          "colors": {
+            "Білий": [
+              {"size": "XS/S", "quantity": 23},
+              {"size": "M/L", "quantity": 23},
+              {"size": "XL/XXL", "quantity": 3}
+            ],
+            "Чорний": [
+              {"size": "M/L", "quantity": 11},
+              {"size": "XS/S", "quantity": 4},
+              {"size": "XL/XXL", "quantity": 3}
+            ]
+          }
+        },
+        {
+          "month": "Серпень",
+          "year": 2025,
+          "colors": {
+            "Білий": [
+              {"size": "M/L", "quantity": 114},
+              {"size": "XS/S", "quantity": 100},
+              {"size": "XL/XXL", "quantity": 57}
+            ],
+            "Чорний": [
+              {"size": "XS/S", "quantity": 59},
+              {"size": "M/L", "quantity": 51},
+              {"size": "XL/XXL", "quantity": 27}
+            ]
+          }
+        }
+      ]
     }
   ]
 };


### PR DESCRIPTION
## Summary
- add July and August 2025 sales entries for the Relaxed Kufaika t-shirt in white and black colorways

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1263ee0dc8333837cf985b4c3de44