### PR TITLE
Display year-over-year deltas

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,8 @@
     <div class="controls">
         <label for="productSelect">Виберіть товар: </label>
         <select id="productSelect"></select>
+        <label for="yearSelect">Виберіть рік: </label>
+        <select id="yearSelect"></select>
         <label for="chartType">Виберіть тип графіка: </label>
         <select id="chartType">
             <option value="byColor">Продажі та попит за кольорами</option>
@@ -31,8 +33,6 @@
             <div id="weeklyDemand" class="total-sales">
                 <h3>Щотижневий попит розмірів по місяцях:</h3>
                 <div class="weekly-demand-controls">
-                    <label for="yearSelect">Виберіть рік: </label>
-                    <select id="yearSelect"></select>
                     <label for="monthSelect">Виберіть місяць: </label>
                     <select id="monthSelect"></select>
                     <label for="colorSelect">Виберіть колір: </label>

--- a/sales-data.js
+++ b/sales-data.js
@@ -5,6 +5,305 @@ export const salesData = {
       "months": [
         {
           "month": "Січень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "L", "quantity": 69},
+              {"size": "M", "quantity": 65},
+              {"size": "XL", "quantity": 23},
+              {"size": "S", "quantity": 22},
+              {"size": "XXL", "quantity": 12},
+              {"size": "3XL", "quantity": 7},
+              {"size": "XS", "quantity": 3}
+            ]
+          }
+        },
+        {
+          "month": "Лютий",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "M", "quantity": 53},
+              {"size": "L", "quantity": 43},
+              {"size": "XL", "quantity": 12},
+              {"size": "S", "quantity": 10},
+              {"size": "XXL", "quantity": 6},
+              {"size": "XS", "quantity": 2},
+              {"size": "3XL", "quantity": 1}
+            ]
+          }
+        },
+        {
+          "month": "Березень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "M", "quantity": 35},
+              {"size": "L", "quantity": 29},
+              {"size": "XL", "quantity": 13},
+              {"size": "XXL", "quantity": 8},
+              {"size": "S", "quantity": 5},
+              {"size": "3XL", "quantity": 3},
+              {"size": "XS", "quantity": 1}
+            ]
+          }
+        },
+        {
+          "month": "Квітень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "M", "quantity": 22},
+              {"size": "L", "quantity": 21},
+              {"size": "XL", "quantity": 7},
+              {"size": "S", "quantity": 3},
+              {"size": "XXL", "quantity": 3}
+            ]
+          }
+        },
+        {
+          "month": "Травень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "L", "quantity": 19},
+              {"size": "M", "quantity": 12},
+              {"size": "XL", "quantity": 7},
+              {"size": "S", "quantity": 5},
+              {"size": "3XL", "quantity": 1},
+              {"size": "XXL", "quantity": 1}
+            ]
+          }
+        },
+        {
+          "month": "Червень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "L", "quantity": 8},
+              {"size": "M", "quantity": 6},
+              {"size": "XL", "quantity": 3},
+              {"size": "S", "quantity": 1},
+              {"size": "XXL", "quantity": 1},
+              {"size": "3XL", "quantity": 1}
+            ]
+          }
+        },
+        {
+          "month": "Липень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "XL", "quantity": 5},
+              {"size": "S", "quantity": 4},
+              {"size": "M", "quantity": 3},
+              {"size": "L", "quantity": 2},
+              {"size": "XXL", "quantity": 1},
+              {"size": "XS", "quantity": 1}
+            ]
+          }
+        },
+        {
+          "month": "Серпень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "M", "quantity": 29},
+              {"size": "L", "quantity": 21},
+              {"size": "XL", "quantity": 13},
+              {"size": "S", "quantity": 7},
+              {"size": "3XL", "quantity": 5},
+              {"size": "XXL", "quantity": 4}
+            ]
+          }
+        },
+        {
+          "month": "Вересень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "M", "quantity": 251},
+              {"size": "L", "quantity": 189},
+              {"size": "XL", "quantity": 139},
+              {"size": "S", "quantity": 101},
+              {"size": "XXL", "quantity": 47},
+              {"size": "XS", "quantity": 11},
+              {"size": "3XL", "quantity": 11}
+            ]
+          }
+        },
+        {
+          "month": "Жовтень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "M", "quantity": 315},
+              {"size": "L", "quantity": 273},
+              {"size": "XL", "quantity": 138},
+              {"size": "S", "quantity": 93},
+              {"size": "XXL", "quantity": 72},
+              {"size": "3XL", "quantity": 22},
+              {"size": "XS", "quantity": 11}
+            ],
+            "Ніжно-рожевий": [
+              {"size": "M", "quantity": 22},
+              {"size": "S", "quantity": 13},
+              {"size": "L", "quantity": 12},
+              {"size": "XL", "quantity": 6},
+              {"size": "XS", "quantity": 1},
+              {"size": "XXL", "quantity": 1}
+            ],
+            "Олива": [
+              {"size": "L", "quantity": 19},
+              {"size": "M", "quantity": 19},
+              {"size": "XXL", "quantity": 10},
+              {"size": "XL", "quantity": 9},
+              {"size": "S", "quantity": 6},
+              {"size": "XS", "quantity": 2},
+              {"size": "3XL", "quantity": 1}
+            ],
+            "Білий": [
+              {"size": "M", "quantity": 8},
+              {"size": "XL", "quantity": 7},
+              {"size": "L", "quantity": 6},
+              {"size": "S", "quantity": 4},
+              {"size": "XXL", "quantity": 2},
+              {"size": "XS", "quantity": 1},
+              {"size": "3XL", "quantity": 1}
+            ],
+            "Сірий Грі": [
+              {"size": "M", "quantity": 7},
+              {"size": "L", "quantity": 4},
+              {"size": "S", "quantity": 2},
+              {"size": "XL", "quantity": 1},
+              {"size": "XXL", "quantity": 1}
+            ],
+            "Бежевий": [
+              {"size": "L", "quantity": 5},
+              {"size": "M", "quantity": 3},
+              {"size": "S", "quantity": 1},
+              {"size": "XXL", "quantity": 1},
+              {"size": "XL", "quantity": 1}
+            ]
+          }
+        },
+        {
+          "month": "Листопад",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "M", "quantity": 370},
+              {"size": "L", "quantity": 343},
+              {"size": "XL", "quantity": 221},
+              {"size": "S", "quantity": 130},
+              {"size": "XXL", "quantity": 81},
+              {"size": "3XL", "quantity": 39},
+              {"size": "XS", "quantity": 17}
+            ],
+            "Білий": [
+              {"size": "M", "quantity": 38},
+              {"size": "L", "quantity": 32},
+              {"size": "S", "quantity": 16},
+              {"size": "XL", "quantity": 15},
+              {"size": "XXL", "quantity": 9},
+              {"size": "XS", "quantity": 3},
+              {"size": "3XL", "quantity": 1}
+            ],
+            "Олива": [
+              {"size": "L", "quantity": 16},
+              {"size": "M", "quantity": 12},
+              {"size": "XL", "quantity": 8},
+              {"size": "S", "quantity": 3},
+              {"size": "XXL", "quantity": 4},
+              {"size": "XS", "quantity": 2},
+              {"size": "3XL", "quantity": 1}
+            ],
+            "Ніжно-рожевий": [
+              {"size": "M", "quantity": 10},
+              {"size": "S", "quantity": 5},
+              {"size": "L", "quantity": 1},
+              {"size": "XL", "quantity": 1},
+              {"size": "XXL", "quantity": 1},
+              {"size": "XS", "quantity": 1}
+            ],
+            "Сірий Грі": [
+              {"size": "M", "quantity": 6},
+              {"size": "L", "quantity": 4},
+              {"size": "XL", "quantity": 4},
+              {"size": "S", "quantity": 1},
+              {"size": "XXL", "quantity": 2},
+              {"size": "XS", "quantity": 1}
+            ],
+            "Бежевий": [
+              {"size": "S", "quantity": 3},
+              {"size": "L", "quantity": 3},
+              {"size": "M", "quantity": 2},
+              {"size": "XXL", "quantity": 2},
+              {"size": "XL", "quantity": 1},
+              {"size": "3XL", "quantity": 1}
+            ]
+          }
+        },
+        {
+          "month": "Грудень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "M", "quantity": 441},
+              {"size": "L", "quantity": 364},
+              {"size": "XL", "quantity": 232},
+              {"size": "S", "quantity": 157},
+              {"size": "XXL", "quantity": 112},
+              {"size": "3XL", "quantity": 39},
+              {"size": "XS", "quantity": 28}
+            ],
+            "Інший Колір": [
+              {"size": "Інший розмір", "quantity": 56}
+            ],
+            "Сірий Грі": [
+              {"size": "M", "quantity": 49},
+              {"size": "L", "quantity": 42},
+              {"size": "S", "quantity": 27},
+              {"size": "XL", "quantity": 19},
+              {"size": "XXL", "quantity": 2},
+              {"size": "XS", "quantity": 1}
+            ],
+            "Ніжно-рожевий": [
+              {"size": "S", "quantity": 33},
+              {"size": "M", "quantity": 32},
+              {"size": "L", "quantity": 26},
+              {"size": "XL", "quantity": 12},
+              {"size": "XS", "quantity": 10}
+            ],
+            "Білий": [
+              {"size": "M", "quantity": 30},
+              {"size": "XL", "quantity": 21},
+              {"size": "S", "quantity": 10},
+              {"size": "L", "quantity": 5},
+              {"size": "XXL", "quantity": 3},
+              {"size": "XS", "quantity": 2},
+              {"size": "3XL", "quantity": 1}
+            ],
+            "Хакі": [
+              {"size": "L", "quantity": 20},
+              {"size": "M", "quantity": 18},
+              {"size": "XL", "quantity": 14},
+              {"size": "S", "quantity": 7},
+              {"size": "XXL", "quantity": 9},
+              {"size": "3XL", "quantity": 1}
+            ],
+            "Бежевий": [
+              {"size": "L", "quantity": 17},
+              {"size": "M", "quantity": 14},
+              {"size": "XL", "quantity": 12},
+              {"size": "S", "quantity": 11},
+              {"size": "XXL", "quantity": 1},
+              {"size": "3XL", "quantity": 1}
+            ]
+          }
+        },
+        {
+          "month": "Січень",
           "year": 2025,
           "colors": {
             "Чорний": [
@@ -633,6 +932,178 @@ export const salesData = {
       "name": "Худі Легкий Kufaika Unisex",
       "months": [
         {
+          "month": "Січень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "L", "quantity": 9},
+              {"size": "M", "quantity": 7},
+              {"size": "XL", "quantity": 3},
+              {"size": "S", "quantity": 2},
+              {"size": "XXL", "quantity": 2}
+            ]
+          }
+        },
+        {
+          "month": "Лютий",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "M", "quantity": 11},
+              {"size": "S", "quantity": 5},
+              {"size": "L", "quantity": 5},
+              {"size": "XL", "quantity": 2},
+              {"size": "XXL", "quantity": 1}
+            ]
+          }
+        },
+        {
+          "month": "Березень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "L", "quantity": 35},
+              {"size": "M", "quantity": 27},
+              {"size": "XL", "quantity": 11},
+              {"size": "S", "quantity": 9},
+              {"size": "XXL", "quantity": 6},
+              {"size": "XS", "quantity": 2},
+              {"size": "3XL", "quantity": 2}
+            ]
+          }
+        },
+        {
+          "month": "Квітень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "M", "quantity": 61},
+              {"size": "L", "quantity": 50},
+              {"size": "XL", "quantity": 32},
+              {"size": "S", "quantity": 24},
+              {"size": "XXL", "quantity": 9},
+              {"size": "3XL", "quantity": 8},
+              {"size": "XS", "quantity": 2}
+            ]
+          }
+        },
+        {
+          "month": "Травень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "M", "quantity": 40},
+              {"size": "L", "quantity": 18},
+              {"size": "XL", "quantity": 8},
+              {"size": "S", "quantity": 5},
+              {"size": "XXL", "quantity": 5},
+              {"size": "XS", "quantity": 2}
+            ]
+          }
+        },
+        {
+          "month": "Червень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "M", "quantity": 32},
+              {"size": "S", "quantity": 12},
+              {"size": "L", "quantity": 12},
+              {"size": "XL", "quantity": 5},
+              {"size": "XS", "quantity": 4},
+              {"size": "XXL", "quantity": 3},
+              {"size": "3XL", "quantity": 3}
+            ]
+          }
+        },
+        {
+          "month": "Липень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "L", "quantity": 19},
+              {"size": "M", "quantity": 9},
+              {"size": "XL", "quantity": 7},
+              {"size": "XXL", "quantity": 5},
+              {"size": "S", "quantity": 3},
+              {"size": "3XL", "quantity": 1}
+            ]
+          }
+        },
+        {
+          "month": "Серпень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "L", "quantity": 43},
+              {"size": "M", "quantity": 39},
+              {"size": "S", "quantity": 15},
+              {"size": "XL", "quantity": 14},
+              {"size": "XXL", "quantity": 3},
+              {"size": "3XL", "quantity": 3},
+              {"size": "XS", "quantity": 1}
+            ]
+          }
+        },
+        {
+          "month": "Вересень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "M", "quantity": 105},
+              {"size": "L", "quantity": 67},
+              {"size": "S", "quantity": 34},
+              {"size": "XL", "quantity": 30},
+              {"size": "XXL", "quantity": 16},
+              {"size": "3XL", "quantity": 10},
+              {"size": "XS", "quantity": 5}
+            ]
+          }
+        },
+        {
+          "month": "Жовтень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "M", "quantity": 31},
+              {"size": "L", "quantity": 21},
+              {"size": "S", "quantity": 13},
+              {"size": "XL", "quantity": 11},
+              {"size": "XXL", "quantity": 10},
+              {"size": "3XL", "quantity": 3},
+              {"size": "XS", "quantity": 1}
+            ]
+          }
+        },
+        {
+          "month": "Листопад",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "M", "quantity": 18},
+              {"size": "L", "quantity": 17},
+              {"size": "S", "quantity": 12},
+              {"size": "XL", "quantity": 11},
+              {"size": "XXL", "quantity": 3},
+              {"size": "XS", "quantity": 2}
+            ]
+          }
+        },
+        {
+          "month": "Грудень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "M", "quantity": 13},
+              {"size": "XL", "quantity": 7},
+              {"size": "S", "quantity": 6},
+              {"size": "L", "quantity": 5},
+              {"size": "3XL", "quantity": 3},
+              {"size": "XXL", "quantity": 1}
+            ]
+          }
+        },
+        {
           "month": "Лютий",
           "year": 2025,
           "colors": {
@@ -742,6 +1213,126 @@ export const salesData = {
     {
       "name": "Світшот Легкий Kufaika Unisex",
       "months": [
+        {
+          "month": "Березень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "M", "quantity": 10},
+              {"size": "L", "quantity": 10},
+              {"size": "S", "quantity": 2},
+              {"size": "XL", "quantity": 1}
+            ]
+          }
+        },
+        {
+          "month": "Квітень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "M", "quantity": 2},
+              {"size": "L", "quantity": 2},
+              {"size": "S", "quantity": 1},
+              {"size": "XL", "quantity": 1}
+            ]
+          }
+        },
+        {
+          "month": "Травень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "S", "quantity": 1},
+              {"size": "M", "quantity": 1},
+              {"size": "L", "quantity": 1}
+            ]
+          }
+        },
+        {
+          "month": "Червень",
+          "year": 2024,
+          "colors": {
+            "Чорний": []
+          }
+        },
+        {
+          "month": "Липень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "L", "quantity": 8},
+              {"size": "XL", "quantity": 3}
+            ]
+          }
+        },
+        {
+          "month": "Серпень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "M", "quantity": 3},
+              {"size": "L", "quantity": 3},
+              {"size": "XL", "quantity": 3},
+              {"size": "S", "quantity": 1}
+            ]
+          }
+        },
+        {
+          "month": "Вересень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "M", "quantity": 10},
+              {"size": "S", "quantity": 6},
+              {"size": "L", "quantity": 4},
+              {"size": "XL", "quantity": 2},
+              {"size": "XXL", "quantity": 1},
+              {"size": "3XL", "quantity": 1}
+            ]
+          }
+        },
+        {
+          "month": "Жовтень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "M", "quantity": 13},
+              {"size": "S", "quantity": 7},
+              {"size": "L", "quantity": 6},
+              {"size": "XS", "quantity": 4},
+              {"size": "XL", "quantity": 2},
+              {"size": "XXL", "quantity": 1}
+            ]
+          }
+        },
+        {
+          "month": "Листопад",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "M", "quantity": 14},
+              {"size": "S", "quantity": 10},
+              {"size": "L", "quantity": 3},
+              {"size": "XXL", "quantity": 4},
+              {"size": "XL", "quantity": 2}
+            ]
+          }
+        },
+        {
+          "month": "Грудень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "M", "quantity": 15},
+              {"size": "S", "quantity": 12},
+              {"size": "L", "quantity": 5},
+              {"size": "XS", "quantity": 3},
+              {"size": "XL", "quantity": 2},
+              {"size": "XXL", "quantity": 1},
+              {"size": "3XL", "quantity": 1}
+            ]
+          }
+        },
         {
           "month": "Січень",
           "year": 2025,
@@ -859,6 +1450,129 @@ export const salesData = {
               {"size": "XS", "quantity": 2},
               {"size": "XXL", "quantity": 2},
               {"size": "3XL", "quantity": 1}
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "Світшот Утеплений Kufaika Unisex",
+      "months": [
+        {
+          "month": "Березень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "L", "quantity": 1}
+            ]
+          }
+        },
+        {
+          "month": "Квітень",
+          "year": 2024,
+          "colors": {
+            "Чорний": []
+          }
+        },
+        {
+          "month": "Травень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "S", "quantity": 1}
+            ]
+          }
+        },
+        {
+          "month": "Червень",
+          "year": 2024,
+          "colors": {
+            "Чорний": []
+          }
+        },
+        {
+          "month": "Липень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "XL", "quantity": 5},
+              {"size": "L", "quantity": 4}
+            ]
+          }
+        },
+        {
+          "month": "Серпень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "XL", "quantity": 1}
+            ]
+          }
+        },
+        {
+          "month": "Вересень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "L", "quantity": 26},
+              {"size": "M", "quantity": 24},
+              {"size": "S", "quantity": 17},
+              {"size": "XL", "quantity": 5},
+              {"size": "XS", "quantity": 2},
+              {"size": "XXL", "quantity": 1},
+              {"size": "3XL", "quantity": 1}
+            ],
+            "Білий": [
+              {"size": "XL", "quantity": 1}
+            ]
+          }
+        },
+        {
+          "month": "Жовтень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "M", "quantity": 45},
+              {"size": "L", "quantity": 41},
+              {"size": "S", "quantity": 15},
+              {"size": "XL", "quantity": 8},
+              {"size": "XXL", "quantity": 3},
+              {"size": "XS", "quantity": 2}
+            ],
+            "Інший Колір": [
+              {"size": "Інший розмір", "quantity": 400}
+            ]
+          }
+        },
+        {
+          "month": "Листопад",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "L", "quantity": 31},
+              {"size": "M", "quantity": 26},
+              {"size": "S", "quantity": 14},
+              {"size": "XL", "quantity": 17},
+              {"size": "XS", "quantity": 4},
+              {"size": "XXL", "quantity": 5},
+              {"size": "3XL", "quantity": 2}
+            ],
+            "Інший Колір": [
+              {"size": "Інший розмір", "quantity": 68}
+            ]
+          }
+        },
+        {
+          "month": "Грудень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "S", "quantity": 46},
+              {"size": "M", "quantity": 39},
+              {"size": "L", "quantity": 33},
+              {"size": "XL", "quantity": 9},
+              {"size": "XXL", "quantity": 6},
+              {"size": "XS", "quantity": 9}
             ]
           }
         }
@@ -1426,6 +2140,134 @@ export const salesData = {
       "name": "Футболка OVERSIZE Kufaika",
       "months": [
         {
+          "month": "Травень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "M/L", "quantity": 6},
+              {"size": "XL/XXL", "quantity": 3},
+              {"size": "XS/S", "quantity": 1}
+            ],
+            "Білий": [
+              {"size": "M/L", "quantity": 6},
+              {"size": "XS/S", "quantity": 2},
+              {"size": "XL/XXL", "quantity": 1}
+            ]
+          }
+        },
+        {
+          "month": "Червень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "M/L", "quantity": 44},
+              {"size": "XS/S", "quantity": 16},
+              {"size": "XL/XXL", "quantity": 10}
+            ],
+            "Білий": [
+              {"size": "M/L", "quantity": 34},
+              {"size": "XS/S", "quantity": 24},
+              {"size": "XL/XXL", "quantity": 12}
+            ]
+          }
+        },
+        {
+          "month": "Липень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "M/L", "quantity": 57},
+              {"size": "XS/S", "quantity": 24},
+              {"size": "XL/XXL", "quantity": 20}
+            ],
+            "Білий": [
+              {"size": "M/L", "quantity": 26},
+              {"size": "XL/XXL", "quantity": 14},
+              {"size": "XS/S", "quantity": 12}
+            ]
+          }
+        },
+        {
+          "month": "Серпень",
+          "year": 2024,
+          "colors": {
+            "Білий": [
+              {"size": "M/L", "quantity": 92},
+              {"size": "XL/XXL", "quantity": 24},
+              {"size": "XS/S", "quantity": 21}
+            ],
+            "Чорний": [
+              {"size": "M/L", "quantity": 62},
+              {"size": "XL/XXL", "quantity": 22},
+              {"size": "XS/S", "quantity": 13}
+            ]
+          }
+        },
+        {
+          "month": "Вересень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "M/L", "quantity": 101},
+              {"size": "XS/S", "quantity": 29},
+              {"size": "XL/XXL", "quantity": 27}
+            ],
+            "Білий": [
+              {"size": "M/L", "quantity": 33},
+              {"size": "XS/S", "quantity": 13},
+              {"size": "XL/XXL", "quantity": 8}
+            ]
+          }
+        },
+        {
+          "month": "Жовтень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "M/L", "quantity": 80},
+              {"size": "XL/XXL", "quantity": 34},
+              {"size": "XS/S", "quantity": 19}
+            ],
+            "Білий": [
+              {"size": "M/L", "quantity": 30},
+              {"size": "XS/S", "quantity": 10},
+              {"size": "XL/XXL", "quantity": 4}
+            ]
+          }
+        },
+        {
+          "month": "Листопад",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "M/L", "quantity": 35},
+              {"size": "XL/XXL", "quantity": 20},
+              {"size": "XS/S", "quantity": 16}
+            ],
+            "Білий": [
+              {"size": "M/L", "quantity": 7},
+              {"size": "XL/XXL", "quantity": 4},
+              {"size": "XS/S", "quantity": 3}
+            ]
+          }
+        },
+        {
+          "month": "Грудень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "M/L", "quantity": 43},
+              {"size": "XL/XXL", "quantity": 31},
+              {"size": "XS/S", "quantity": 7}
+            ],
+            "Білий": [
+              {"size": "M/L", "quantity": 19},
+              {"size": "XS/S", "quantity": 11},
+              {"size": "XL/XXL", "quantity": 2}
+            ]
+          }
+        },
+        {
           "month": "Січень",
           "year": 2025,
           "colors": {
@@ -1550,6 +2392,547 @@ export const salesData = {
               {"size": "M/L", "quantity": 171},
               {"size": "XL/XXL", "quantity": 93},
               {"size": "XS/S", "quantity": 64}
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "Футболка Relaxed Kufaika",
+      "months": [
+        {
+          "month": "Липень",
+          "year": 2025,
+          "colors": {
+            "Білий": [
+              {"size": "XS/S", "quantity": 23},
+              {"size": "M/L", "quantity": 23},
+              {"size": "XL/XXL", "quantity": 3}
+            ],
+            "Чорний": [
+              {"size": "M/L", "quantity": 11},
+              {"size": "XS/S", "quantity": 4},
+              {"size": "XL/XXL", "quantity": 3}
+            ]
+          }
+        },
+        {
+          "month": "Серпень",
+          "year": 2025,
+          "colors": {
+            "Білий": [
+              {"size": "M/L", "quantity": 114},
+              {"size": "XS/S", "quantity": 100},
+              {"size": "XL/XXL", "quantity": 57}
+            ],
+            "Чорний": [
+              {"size": "XS/S", "quantity": 59},
+              {"size": "M/L", "quantity": 51},
+              {"size": "XL/XXL", "quantity": 27}
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "Футболка Lightness Kufaika",
+      "months": [
+        {
+          "month": "Липень",
+          "year": 2025,
+          "colors": {
+            "Білий": [
+              {"size": "M", "quantity": 8},
+              {"size": "S", "quantity": 5},
+              {"size": "XS", "quantity": 4},
+              {"size": "L", "quantity": 4}
+            ],
+            "Чорний": [
+              {"size": "M", "quantity": 6},
+              {"size": "S", "quantity": 2},
+              {"size": "L", "quantity": 2},
+              {"size": "XL", "quantity": 1}
+            ]
+          }
+        },
+        {
+          "month": "Серпень",
+          "year": 2025,
+          "colors": {
+            "Чорний": [
+              {"size": "M", "quantity": 19},
+              {"size": "L", "quantity": 18},
+              {"size": "XL", "quantity": 15},
+              {"size": "S", "quantity": 10},
+              {"size": "2XL", "quantity": 8},
+              {"size": "XS", "quantity": 6},
+              {"size": "3XL", "quantity": 2}
+            ],
+            "Білий": [
+              {"size": "L", "quantity": 6},
+              {"size": "XL", "quantity": 6},
+              {"size": "M", "quantity": 5},
+              {"size": "S", "quantity": 4},
+              {"size": "2XL", "quantity": 4},
+              {"size": "XS", "quantity": 3},
+              {"size": "3XL", "quantity": 1}
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "Футболка Premium Kufaika",
+      "months": [
+        {
+          "month": "Квітень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "M", "quantity": 193},
+              {"size": "L", "quantity": 176},
+              {"size": "S", "quantity": 110},
+              {"size": "XL", "quantity": 75},
+              {"size": "XS", "quantity": 39},
+              {"size": "XXL", "quantity": 26},
+              {"size": "3XL", "quantity": 5}
+            ],
+            "Білий": [
+              {"size": "M", "quantity": 16},
+              {"size": "L", "quantity": 12},
+              {"size": "XL", "quantity": 8},
+              {"size": "S", "quantity": 6},
+              {"size": "XXL", "quantity": 2}
+            ]
+          }
+        },
+        {
+          "month": "Травень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "M", "quantity": 254},
+              {"size": "L", "quantity": 197},
+              {"size": "XL", "quantity": 98},
+              {"size": "S", "quantity": 74},
+              {"size": "XXL", "quantity": 44},
+              {"size": "XS", "quantity": 12},
+              {"size": "3XL", "quantity": 13}
+            ],
+            "Білий": [
+              {"size": "M", "quantity": 57},
+              {"size": "L", "quantity": 41},
+              {"size": "S", "quantity": 39},
+              {"size": "XS", "quantity": 25},
+              {"size": "XL", "quantity": 18},
+              {"size": "XXL", "quantity": 10},
+              {"size": "3XL", "quantity": 5}
+            ]
+          }
+        },
+        {
+          "month": "Червень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "M", "quantity": 316},
+              {"size": "L", "quantity": 264},
+              {"size": "XL", "quantity": 163},
+              {"size": "S", "quantity": 121},
+              {"size": "XXL", "quantity": 44},
+              {"size": "XS", "quantity": 16},
+              {"size": "3XL", "quantity": 14}
+            ],
+            "Білий": [
+              {"size": "M", "quantity": 66},
+              {"size": "L", "quantity": 65},
+              {"size": "S", "quantity": 39},
+              {"size": "XL", "quantity": 34},
+              {"size": "XS", "quantity": 12},
+              {"size": "XXL", "quantity": 5}
+            ],
+            "Олива": [
+              {"size": "M", "quantity": 12},
+              {"size": "L", "quantity": 4},
+              {"size": "S", "quantity": 4},
+              {"size": "XXL", "quantity": 4},
+              {"size": "XL", "quantity": 1}
+            ],
+            "Ніжно-рожевий": [
+              {"size": "M", "quantity": 9},
+              {"size": "S", "quantity": 6},
+              {"size": "L", "quantity": 4},
+              {"size": "XXL", "quantity": 1},
+              {"size": "XS", "quantity": 1},
+              {"size": "XL", "quantity": 1}
+            ],
+            "Бежевий": [
+              {"size": "M", "quantity": 8},
+              {"size": "L", "quantity": 4},
+              {"size": "S", "quantity": 2},
+              {"size": "XXL", "quantity": 1}
+            ],
+            "Сірий": [
+              {"size": "M", "quantity": 8},
+              {"size": "L", "quantity": 8},
+              {"size": "XL", "quantity": 4},
+              {"size": "S", "quantity": 2},
+              {"size": "XXL", "quantity": 3}
+            ]
+          }
+        },
+        {
+          "month": "Липень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "M", "quantity": 481},
+              {"size": "L", "quantity": 359},
+              {"size": "XL", "quantity": 246},
+              {"size": "S", "quantity": 153},
+              {"size": "XXL", "quantity": 106},
+              {"size": "XS", "quantity": 26},
+              {"size": "3XL", "quantity": 48}
+            ],
+            "Білий": [
+              {"size": "M", "quantity": 122},
+              {"size": "L", "quantity": 91},
+              {"size": "S", "quantity": 62},
+              {"size": "XL", "quantity": 43},
+              {"size": "XXL", "quantity": 27},
+              {"size": "XS", "quantity": 11},
+              {"size": "3XL", "quantity": 13}
+            ],
+            "Олива": [
+              {"size": "L", "quantity": 66},
+              {"size": "M", "quantity": 57},
+              {"size": "S", "quantity": 22},
+              {"size": "XL", "quantity": 34},
+              {"size": "XXL", "quantity": 15},
+              {"size": "XS", "quantity": 2}
+            ],
+            "Бежевий": [
+              {"size": "L", "quantity": 33},
+              {"size": "M", "quantity": 31},
+              {"size": "S", "quantity": 11},
+              {"size": "XL", "quantity": 11},
+              {"size": "XXL", "quantity": 5},
+              {"size": "XS", "quantity": 3}
+            ],
+            "Ніжно-рожевий": [
+              {"size": "M", "quantity": 30},
+              {"size": "S", "quantity": 17},
+              {"size": "L", "quantity": 12},
+              {"size": "XL", "quantity": 10},
+              {"size": "XS", "quantity": 8},
+              {"size": "XXL", "quantity": 3}
+            ],
+            "Сірий": [
+              {"size": "M", "quantity": 21},
+              {"size": "L", "quantity": 14},
+              {"size": "XL", "quantity": 6},
+              {"size": "S", "quantity": 5},
+              {"size": "XXL", "quantity": 7},
+              {"size": "XS", "quantity": 1}
+            ]
+          }
+        },
+        {
+          "month": "Серпень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "M", "quantity": 342},
+              {"size": "L", "quantity": 276},
+              {"size": "XL", "quantity": 144},
+              {"size": "S", "quantity": 120},
+              {"size": "XXL", "quantity": 65},
+              {"size": "XS", "quantity": 19},
+              {"size": "3XL", "quantity": 24}
+            ],
+            "Білий": [
+              {"size": "M", "quantity": 67},
+              {"size": "L", "quantity": 52},
+              {"size": "S", "quantity": 35},
+              {"size": "XL", "quantity": 23},
+              {"size": "XXL", "quantity": 10},
+              {"size": "XS", "quantity": 8},
+              {"size": "3XL", "quantity": 5}
+            ],
+            "Олива": [
+              {"size": "L", "quantity": 46},
+              {"size": "M", "quantity": 45},
+              {"size": "XL", "quantity": 25},
+              {"size": "S", "quantity": 12},
+              {"size": "XXL", "quantity": 15},
+              {"size": "XS", "quantity": 3},
+              {"size": "3XL", "quantity": 1}
+            ],
+            "Ніжно-рожевий": [
+              {"size": "M", "quantity": 25},
+              {"size": "S", "quantity": 21},
+              {"size": "L", "quantity": 8},
+              {"size": "XL", "quantity": 4},
+              {"size": "XS", "quantity": 7},
+              {"size": "XXL", "quantity": 3}
+            ],
+            "Бежевий": [
+              {"size": "M", "quantity": 17},
+              {"size": "L", "quantity": 7},
+              {"size": "S", "quantity": 8},
+              {"size": "XL", "quantity": 3},
+              {"size": "XXL", "quantity": 5},
+              {"size": "XS", "quantity": 1}
+            ],
+            "Сірий": [
+              {"size": "M", "quantity": 34},
+              {"size": "L", "quantity": 26},
+              {"size": "XL", "quantity": 13},
+              {"size": "S", "quantity": 11},
+              {"size": "XXL", "quantity": 4},
+              {"size": "XS", "quantity": 8},
+              {"size": "3XL", "quantity": 4}
+            ],
+            "Койот": [
+              {"size": "M", "quantity": 14},
+              {"size": "L", "quantity": 5},
+              {"size": "XL", "quantity": 4},
+              {"size": "S", "quantity": 3},
+              {"size": "XXL", "quantity": 2},
+              {"size": "XS", "quantity": 1}
+            ]
+          }
+        },
+        {
+          "month": "Вересень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "M", "quantity": 229},
+              {"size": "L", "quantity": 191},
+              {"size": "XL", "quantity": 108},
+              {"size": "S", "quantity": 79},
+              {"size": "XXL", "quantity": 58},
+              {"size": "3XL", "quantity": 17},
+              {"size": "XS", "quantity": 6}
+            ],
+            "Білий": [
+              {"size": "M", "quantity": 76},
+              {"size": "L", "quantity": 39},
+              {"size": "S", "quantity": 24},
+              {"size": "XL", "quantity": 16},
+              {"size": "XXL", "quantity": 3},
+              {"size": "XS", "quantity": 2},
+              {"size": "3XL", "quantity": 3}
+            ],
+            "Олива": [
+              {"size": "L", "quantity": 40},
+              {"size": "M", "quantity": 26},
+              {"size": "S", "quantity": 15},
+              {"size": "XL", "quantity": 15},
+              {"size": "XXL", "quantity": 8},
+              {"size": "XS", "quantity": 1},
+              {"size": "3XL", "quantity": 5}
+            ],
+            "Ніжно-рожевий": [
+              {"size": "S", "quantity": 16},
+              {"size": "M", "quantity": 14},
+              {"size": "L", "quantity": 12},
+              {"size": "XL", "quantity": 4},
+              {"size": "XS", "quantity": 3},
+              {"size": "XXL", "quantity": 1}
+            ],
+            "Бежевий": [
+              {"size": "L", "quantity": 14},
+              {"size": "M", "quantity": 6},
+              {"size": "XL", "quantity": 3},
+              {"size": "S", "quantity": 1},
+              {"size": "XXL", "quantity": 2}
+            ],
+            "Сірий": [
+              {"size": "M", "quantity": 17},
+              {"size": "L", "quantity": 11},
+              {"size": "S", "quantity": 11},
+              {"size": "XL", "quantity": 7},
+              {"size": "XS", "quantity": 8},
+              {"size": "XXL", "quantity": 1},
+              {"size": "3XL", "quantity": 2}
+            ],
+            "Койот": [
+              {"size": "L", "quantity": 25},
+              {"size": "M", "quantity": 15},
+              {"size": "XL", "quantity": 10},
+              {"size": "XXL", "quantity": 8},
+              {"size": "S", "quantity": 7},
+              {"size": "XS", "quantity": 1}
+            ]
+          }
+        },
+        {
+          "month": "Жовтень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "L", "quantity": 272},
+              {"size": "M", "quantity": 257},
+              {"size": "XL", "quantity": 190},
+              {"size": "S", "quantity": 179},
+              {"size": "XXL", "quantity": 35},
+              {"size": "3XL", "quantity": 16},
+              {"size": "XS", "quantity": 16}
+            ],
+            "Білий": [
+              {"size": "M", "quantity": 155},
+              {"size": "L", "quantity": 141},
+              {"size": "S", "quantity": 138},
+              {"size": "XL", "quantity": 103},
+              {"size": "XS", "quantity": 12},
+              {"size": "XXL", "quantity": 2},
+              {"size": "3XL", "quantity": 3}
+            ],
+            "Олива": [
+              {"size": "M", "quantity": 14},
+              {"size": "L", "quantity": 13},
+              {"size": "S", "quantity": 10},
+              {"size": "XL", "quantity": 7},
+              {"size": "XXL", "quantity": 3}
+            ],
+            "Койот": [
+              {"size": "L", "quantity": 16},
+              {"size": "M", "quantity": 13},
+              {"size": "XL", "quantity": 4},
+              {"size": "S", "quantity": 6},
+              {"size": "XXL", "quantity": 3}
+            ],
+            "Бежевий": [
+              {"size": "L", "quantity": 10},
+              {"size": "M", "quantity": 7},
+              {"size": "XL", "quantity": 9},
+              {"size": "S", "quantity": 3},
+              {"size": "XXL", "quantity": 2},
+              {"size": "3XL", "quantity": 5}
+            ],
+            "Сірий": [
+              {"size": "L", "quantity": 11},
+              {"size": "M", "quantity": 4},
+              {"size": "S", "quantity": 6},
+              {"size": "XL", "quantity": 1}
+            ],
+            "Ніжно-рожевий": [
+              {"size": "S", "quantity": 6},
+              {"size": "M", "quantity": 5},
+              {"size": "L", "quantity": 5},
+              {"size": "XL", "quantity": 4},
+              {"size": "XS", "quantity": 3}
+            ]
+          }
+        },
+        {
+          "month": "Листопад",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "M", "quantity": 207},
+              {"size": "L", "quantity": 138},
+              {"size": "XL", "quantity": 117},
+              {"size": "S", "quantity": 37},
+              {"size": "XXL", "quantity": 28},
+              {"size": "3XL", "quantity": 16},
+              {"size": "XS", "quantity": 6}
+            ],
+            "Сірий": [
+              {"size": "M", "quantity": 33},
+              {"size": "L", "quantity": 15},
+              {"size": "S", "quantity": 13},
+              {"size": "XL", "quantity": 9},
+              {"size": "XS", "quantity": 1},
+              {"size": "XXL", "quantity": 1},
+              {"size": "3XL", "quantity": 2}
+            ],
+            "Білий": [
+              {"size": "M", "quantity": 33},
+              {"size": "L", "quantity": 16},
+              {"size": "XL", "quantity": 6},
+              {"size": "S", "quantity": 5},
+              {"size": "XXL", "quantity": 3},
+              {"size": "XS", "quantity": 3}
+            ],
+            "Олива": [
+              {"size": "XL", "quantity": 12},
+              {"size": "L", "quantity": 9},
+              {"size": "M", "quantity": 5},
+              {"size": "S", "quantity": 3},
+              {"size": "XS", "quantity": 3}
+            ],
+            "Койот": [
+              {"size": "L", "quantity": 10},
+              {"size": "XL", "quantity": 10},
+              {"size": "M", "quantity": 8},
+              {"size": "S", "quantity": 5},
+              {"size": "XXL", "quantity": 1}
+            ],
+            "Ніжно-рожевий": [
+              {"size": "M", "quantity": 8},
+              {"size": "S", "quantity": 4},
+              {"size": "XS", "quantity": 3},
+              {"size": "L", "quantity": 1},
+              {"size": "XL", "quantity": 2}
+            ]
+          }
+        },
+        {
+          "month": "Грудень",
+          "year": 2024,
+          "colors": {
+            "Чорний": [
+              {"size": "M", "quantity": 172},
+              {"size": "L", "quantity": 132},
+              {"size": "XL", "quantity": 86},
+              {"size": "S", "quantity": 48},
+              {"size": "XXL", "quantity": 34},
+              {"size": "XS", "quantity": 24},
+              {"size": "3XL", "quantity": 7}
+            ],
+            "Білий": [
+              {"size": "M", "quantity": 27},
+              {"size": "L", "quantity": 21},
+              {"size": "S", "quantity": 16},
+              {"size": "XL", "quantity": 10},
+              {"size": "XXL", "quantity": 1},
+              {"size": "XS", "quantity": 1}
+            ],
+            "Олива": [
+              {"size": "M", "quantity": 13},
+              {"size": "L", "quantity": 12},
+              {"size": "XL", "quantity": 9},
+              {"size": "S", "quantity": 5},
+              {"size": "XXL", "quantity": 2},
+              {"size": "XS", "quantity": 3},
+              {"size": "3XL", "quantity": 3}
+            ],
+            "Ніжно-рожевий": [
+              {"size": "S", "quantity": 12},
+              {"size": "M", "quantity": 7},
+              {"size": "L", "quantity": 5},
+              {"size": "XS", "quantity": 5},
+              {"size": "XL", "quantity": 2},
+              {"size": "XXL", "quantity": 1}
+            ],
+            "Сірий": [
+              {"size": "S", "quantity": 6},
+              {"size": "M", "quantity": 4},
+              {"size": "L", "quantity": 3},
+              {"size": "XL", "quantity": 4}
+            ],
+            "Бежевий": [
+              {"size": "L", "quantity": 5},
+              {"size": "M", "quantity": 3},
+              {"size": "S", "quantity": 1}
+            ],
+            "Койот": [
+              {"size": "L", "quantity": 4},
+              {"size": "M", "quantity": 1},
+              {"size": "XL", "quantity": 1}
             ]
           }
         }

--- a/script.js
+++ b/script.js
@@ -2,7 +2,7 @@ import { salesData } from './sales-data.js';
 
 let salesChart, dailyDemandChart;
 // Define preferred size order for consistent display
-const sizeOrder = ['XS', 'XS/S', 'S', 'M', 'M/L', 'L', 'XL', 'XL/XXL', 'XXL', '3XL'];
+const sizeOrder = ['XS', 'XS/S', 'S', 'M', 'M/L', 'L', 'XL', 'XL/XXL', '2XL', 'XXL', '3XL'];
 // Function to assign colors
 function getColor(name) {
     const colorMap = {
@@ -53,6 +53,38 @@ function getProductSizes(productData) {
 function calculateTotalSales(data) {
     return data.reduce((sum, value) => sum + value, 0);
 }
+
+function formatNumber(value, decimals = 0) {
+    const factor = Math.pow(10, decimals);
+    let rounded = Math.round(value * factor) / factor;
+    if (Object.is(rounded, -0)) {
+        rounded = 0;
+    }
+    if (decimals > 0) {
+        return rounded
+            .toFixed(decimals)
+            .replace(/\.0+$/, '')
+            .replace(/(\.\d*[1-9])0+$/, '$1');
+    }
+    return rounded.toString();
+}
+
+function formatDelta(delta, decimals = 0) {
+    if (delta === null || typeof delta === 'undefined') {
+        return '';
+    }
+    const factor = Math.pow(10, decimals);
+    let roundedDelta = Math.round(delta * factor) / factor;
+    if (Object.is(roundedDelta, -0)) {
+        roundedDelta = 0;
+    }
+    const sign = roundedDelta > 0 ? '+' : '';
+    const className = roundedDelta > 0 ? 'positive' : roundedDelta < 0 ? 'negative' : 'neutral';
+    const formatted = decimals > 0
+        ? formatNumber(roundedDelta, decimals)
+        : formatNumber(roundedDelta, 0);
+    return `<span class="diff ${className}">(${sign}${formatted})</span>`;
+}
 // Helper to get month index (0-based)
 function getMonthIndex(monthName) {
     const monthMap = {
@@ -65,15 +97,113 @@ function getMonthIndex(monthName) {
 function getDaysInMonth(month, year) {
     return new Date(year, getMonthIndex(month) + 1, 0).getDate();
 }
+
+function deduplicateProducts(products) {
+    const productMap = new Map();
+    products.forEach(product => {
+        if (!productMap.has(product.name)) {
+            productMap.set(product.name, {
+                name: product.name,
+                months: []
+            });
+        }
+        const mergedProduct = productMap.get(product.name);
+        product.months.forEach(month => {
+            const existingMonth = mergedProduct.months.find(
+                m => m.year === month.year && m.month === month.month
+            );
+            if (!existingMonth) {
+                mergedProduct.months.push({
+                    month: month.month,
+                    year: month.year,
+                    colors: Object.fromEntries(
+                        Object.entries(month.colors).map(([color, sizes]) => [
+                            color,
+                            sizes.map(item => ({ ...item }))
+                        ])
+                    )
+                });
+            } else {
+                Object.entries(month.colors).forEach(([color, sizes]) => {
+                    if (!existingMonth.colors[color]) {
+                        existingMonth.colors[color] = sizes.map(item => ({ ...item }));
+                    } else {
+                        const sizeMap = new Map(
+                            existingMonth.colors[color].map(item => [item.size, item.quantity])
+                        );
+                        sizes.forEach(item => {
+                            sizeMap.set(item.size, (sizeMap.get(item.size) || 0) + item.quantity);
+                        });
+                        existingMonth.colors[color] = Array.from(sizeMap, ([size, quantity]) => ({
+                            size,
+                            quantity
+                        }));
+                    }
+                });
+            }
+        });
+        mergedProduct.months.sort((a, b) => {
+            if (a.year !== b.year) {
+                return a.year - b.year;
+            }
+            return getMonthIndex(a.month) - getMonthIndex(b.month);
+        });
+    });
+    return Array.from(productMap.values());
+}
+
+const normalizedProducts = deduplicateProducts(salesData.products);
+
+function getProductByName(name) {
+    return normalizedProducts.find(product => product.name === name) || null;
+}
+
+function getSelectedYear() {
+    const yearElement = document.getElementById('yearSelect');
+    if (!yearElement) {
+        return null;
+    }
+    const yearValue = parseInt(yearElement.value, 10);
+    return Number.isNaN(yearValue) ? null : yearValue;
+}
 // Function to update total sales display
-function updateTotalSales(datasets) {
+function updateTotalSales(productData, filteredMonths, chartType, datasets) {
     const totalSalesDiv = document.getElementById('totalSales');
     let html = '<h3>Загальні суми продажів:</h3><ul>';
+    const selectedYear = filteredMonths.length > 0 ? filteredMonths[0].year : null;
+    const previousYear = selectedYear !== null ? selectedYear - 1 : null;
+    const monthNames = filteredMonths.map(month => month.month);
+    const previousYearMonths = previousYear !== null
+        ? productData.months.filter(month => month.year === previousYear && monthNames.includes(month.month))
+        : [];
+    const hasPreviousData = previousYearMonths.length > 0;
     datasets.forEach(dataset => {
         const total = calculateTotalSales(dataset.data);
         const label = dataset.label.split(' (Щоденний)')[0];
         const color = getColor(label);
-        html += `<li><span class="label"><span class="color-square" style="background-color: ${color};"></span>${label}</span><span class="value">${total}</span></li>`;
+        let previousTotal = 0;
+        if (hasPreviousData) {
+            if (chartType === 'byColor') {
+                previousTotal = previousYearMonths.reduce((sum, month) => {
+                    const colorData = month.colors[label];
+                    if (!colorData) {
+                        return sum;
+                    }
+                    return sum + colorData.reduce((acc, item) => acc + item.quantity, 0);
+                }, 0);
+            } else {
+                previousTotal = previousYearMonths.reduce((sum, month) => {
+                    const colorData = month.colors[chartType];
+                    if (!colorData) {
+                        return sum;
+                    }
+                    const item = colorData.find(i => i.size === label);
+                    return sum + (item ? item.quantity : 0);
+                }, 0);
+            }
+        }
+        const diffHtml = hasPreviousData ? formatDelta(total - previousTotal) : '';
+        html += `<li><span class="label"><span class="color-square" style="background-color: ${color};"></span>${label}</span><span class="value">${total}${diffHtml ? ` ${diffHtml}` : ''}</span></li>`;
     });
     html += '</ul>';
     totalSalesDiv.innerHTML = html;
@@ -95,7 +225,11 @@ function updateWeeklyDemand(productData) {
     const productSizes = getProductSizes(productData);
     const daysInMonth = getDaysInMonth(month.month, month.year);
     const weeksInMonth = daysInMonth / 7;
+    const previousYear = month.year - 1;
+    const previousMonth = productData.months.find(m => m.year === previousYear && m.month === month.month) || null;
+    const previousWeeksInMonth = previousMonth ? getDaysInMonth(previousMonth.month, previousMonth.year) / 7 : null;
     let totalWeekly = 0; // Для пункту "Усього"
+    let totalPreviousWeekly = 0;
     html += `<h4><span class="color-square" style="background-color: ${colorHex};"></span>${colorSelect}</h4>`;
     html += '<ul class="fade-in">';
     productSizes.forEach(size => {
@@ -103,13 +237,26 @@ function updateWeeklyDemand(productData) {
         const item = colorData ? colorData.find(i => i.size === size) : null;
         const total = item ? item.quantity : 0;
         const weekly = Math.round(total / weeksInMonth * 10) / 10;
-        if (weekly > 0) {
-            html += `<li class="fade-in"><span class="label">${size}</span><span class="value">${weekly}</span></li>`;
-            totalWeekly += weekly;
+        let previousWeekly = null;
+        if (previousMonth && previousWeeksInMonth) {
+            const previousColorData = previousMonth.colors[colorSelect] || [];
+            const previousItem = previousColorData.find(i => i.size === size) || null;
+            const previousTotal = previousItem ? previousItem.quantity : 0;
+            previousWeekly = Math.round(previousTotal / previousWeeksInMonth * 10) / 10;
         }
+        if (previousWeekly !== null) {
+            totalPreviousWeekly += previousWeekly;
+        }
+        if (weekly > 0) {
+            const diffHtml = previousWeekly !== null ? formatDelta(weekly - previousWeekly, 1) : '';
+            html += `<li class="fade-in"><span class="label">${size}</span><span class="value">${weekly}${diffHtml ? ` ${diffHtml}` : ''}</span></li>`;
+        }
+        totalWeekly += weekly;
     });
     totalWeekly = Math.round(totalWeekly * 10) / 10; // Округлення до 1 знака
-    html += `<li class="fade-in"><span class="label">Усього</span><span class="value">${totalWeekly}</span></li>`;
+    totalPreviousWeekly = Math.round(totalPreviousWeekly * 10) / 10;
+    const totalDiffHtml = previousMonth && previousWeeksInMonth ? formatDelta(totalWeekly - totalPreviousWeekly, 1) : '';
+    html += `<li class="fade-in"><span class="label">Усього</span><span class="value">${totalWeekly}${totalDiffHtml ? ` ${totalDiffHtml}` : ''}</span></li>`;
     html += '</ul>';
     weeklyDemandList.innerHTML = html;
     // Remove fade-in class after animation completes
@@ -121,12 +268,11 @@ function updateWeeklyDemand(productData) {
     }, 500); // Matches animation duration
 }
 // Function to calculate daily demand data
-function calculateDailyDemandData(productData, chartType) {
-    const months = productData.months;
+function calculateDailyDemandData(productData, months, chartType) {
     const datasets = [];
     const productSizes = getProductSizes(productData);
     if (chartType === 'byColor') {
-        const colors = getProductColors(productData);
+        const colors = getProductColors(productData, months);
         colors.forEach(color => {
             const data = months.map(month => {
                 const daysInMonth = getDaysInMonth(month.month, month.year);
@@ -167,9 +313,10 @@ function calculateDailyDemandData(productData, chartType) {
     return datasets;
 }
 // Function to get colors for a product
-function getProductColors(productData) {
+function getProductColors(productData, monthsSubset = null) {
     const colorSet = new Set();
-    productData.months.forEach(month => {
+    const sourceMonths = monthsSubset || productData.months;
+    sourceMonths.forEach(month => {
         Object.keys(month.colors).forEach(color => colorSet.add(color));
     });
     return Array.from(colorSet);
@@ -177,84 +324,106 @@ function getProductColors(productData) {
 // Function to update year dropdown
 function updateYearSelect(productData) {
     const yearSelect = document.getElementById('yearSelect');
+    const previousValue = yearSelect.value;
     yearSelect.innerHTML = '';
-    const years = new Set();
-    productData.months.forEach(month => years.add(month.year));
-    Array.from(years).sort().forEach(year => {
+    const years = Array.from(new Set(productData.months.map(month => month.year))).sort((a, b) => a - b);
+    years.forEach(year => {
         const option = document.createElement('option');
         option.value = year;
         option.textContent = year;
         yearSelect.appendChild(option);
     });
-    if (years.size === 0) {
+    if (years.length === 0) {
         yearSelect.innerHTML = '<option value="">Немає років</option>';
+        return;
     }
+    const fallbackYear = String(years[0]);
+    const selectedYear = years.map(String).includes(previousValue) ? previousValue : fallbackYear;
+    yearSelect.value = selectedYear;
 }
 // Function to update month dropdown
 function updateMonthSelect(productData) {
-    const yearSelect = document.getElementById('yearSelect').value;
     const monthSelect = document.getElementById('monthSelect');
+    const previousValue = monthSelect.value;
+    const yearSelectValue = parseInt(document.getElementById('yearSelect').value, 10);
     monthSelect.innerHTML = '';
-    const months = new Set();
-    productData.months
-        .filter(month => month.year === parseInt(yearSelect))
-        .forEach(month => months.add(month.month));
-    Array.from(months).forEach(month => {
+    if (Number.isNaN(yearSelectValue)) {
+        monthSelect.innerHTML = '<option value="">Немає місяців</option>';
+        return;
+    }
+    const months = Array.from(new Set(
+        productData.months
+            .filter(month => month.year === yearSelectValue)
+            .map(month => month.month)
+    )).sort((a, b) => getMonthIndex(a) - getMonthIndex(b));
+    months.forEach(month => {
         const option = document.createElement('option');
         option.value = month;
         option.textContent = month;
         monthSelect.appendChild(option);
     });
-    if (months.size === 0) {
+    if (months.length === 0) {
         monthSelect.innerHTML = '<option value="">Немає місяців</option>';
+        return;
     }
+    const fallbackMonth = months[0];
+    const selectedMonth = months.includes(previousValue) ? previousValue : fallbackMonth;
+    monthSelect.value = selectedMonth;
 }
 // Function to update color dropdown
 function updateColorSelect(productData) {
-    const yearSelect = document.getElementById('yearSelect').value;
-    const monthSelect = document.getElementById('monthSelect').value;
     const colorSelect = document.getElementById('colorSelect');
+    const previousValue = colorSelect.value;
+    const yearSelectValue = parseInt(document.getElementById('yearSelect').value, 10);
+    const monthSelectValue = document.getElementById('monthSelect').value;
     colorSelect.innerHTML = '';
-    const colors = new Set();
-    productData.months
-        .filter(month => month.year === parseInt(yearSelect) && month.month === monthSelect)
-        .forEach(month => {
-            Object.keys(month.colors).forEach(color => colors.add(color));
-        });
-    Array.from(colors).forEach(color => {
+    if (Number.isNaN(yearSelectValue) || !monthSelectValue) {
+        colorSelect.innerHTML = '<option value="">Немає кольорів</option>';
+        return;
+    }
+    const colors = Array.from(new Set(
+        productData.months
+            .filter(month => month.year === yearSelectValue && month.month === monthSelectValue)
+            .flatMap(month => Object.keys(month.colors))
+    )).sort((a, b) => a.localeCompare(b, 'uk'));
+    colors.forEach(color => {
         const option = document.createElement('option');
         option.value = color;
         option.textContent = color;
         colorSelect.appendChild(option);
     });
-    if (colors.size === 0) {
+    if (colors.length === 0) {
         colorSelect.innerHTML = '<option value="">Немає кольорів</option>';
+        return;
     }
+    const fallbackColor = colors[0];
+    const selectedColor = colors.includes(previousValue) ? previousValue : fallbackColor;
+    colorSelect.value = selectedColor;
 }
 // Function to update product dropdown
 function updateProductSelect() {
     const productSelect = document.getElementById('productSelect');
     productSelect.innerHTML = '';
-    if (!salesData.products || salesData.products.length === 0) {
+    if (!normalizedProducts || normalizedProducts.length === 0) {
         productSelect.innerHTML = '<option value="">Немає продуктів</option>';
         document.getElementById('totalSales').innerHTML = '<p style="color: red;">Помилка: Немає продуктів у даних</p>';
-        console.error('salesData.products is empty or undefined');
+        console.error('normalizedProducts is empty or undefined');
         return;
     }
-    salesData.products.forEach(product => {
+    normalizedProducts.forEach(product => {
         const option = document.createElement('option');
         option.value = product.name;
         option.textContent = product.name;
         productSelect.appendChild(option);
     });
-    console.log('Product select updated with', salesData.products.length, 'products');
+    console.log('Product select updated with', normalizedProducts.length, 'products');
 }
 // Function to update chart type dropdown
 function updateChartTypes() {
     const productSelect = document.getElementById('productSelect').value;
     const chartTypeSelect = document.getElementById('chartType');
     chartTypeSelect.innerHTML = '<option value="byColor">Продажі та попит за кольорами</option>';
-    const productData = salesData.products.find(p => p.name === productSelect);
+    const productData = getProductByName(productSelect);
     if (!productData) {
         console.error('No product data for', productSelect);
         return;
@@ -274,7 +443,7 @@ function updateChart() {
     const chartType = document.getElementById('chartType').value;
     const salesChartTitle = document.getElementById('salesChartTitle');
     const dailyDemandChartTitle = document.getElementById('dailyDemandChartTitle');
-    const productData = salesData.products.find(p => p.name === productSelect);
+    const productData = getProductByName(productSelect);
     if (!productData) {
         salesChartTitle.textContent = 'Дані недоступні';
         dailyDemandChartTitle.textContent = 'Дані недоступні';
@@ -283,18 +452,31 @@ function updateChart() {
         console.error('Product not found:', productSelect);
         return;
     }
-    // Update weekly demand dropdowns
-    updateYearSelect(productData);
-    updateMonthSelect(productData);
-    updateColorSelect(productData);
-    updateWeeklyDemand(productData);
-    const colors = getProductColors(productData);
-    const months = productData.months.map(m => `${m.month} ${m.year}`);
+    const selectedYear = getSelectedYear();
+    const filteredMonths = selectedYear === null
+        ? productData.months
+        : productData.months.filter(month => month.year === selectedYear);
+    if (filteredMonths.length === 0) {
+        salesChartTitle.textContent = `Немає даних для ${productSelect} у ${selectedYear} році`;
+        dailyDemandChartTitle.textContent = `Немає даних для ${productSelect} у ${selectedYear} році`;
+        if (salesChart) {
+            salesChart.destroy();
+            salesChart = null;
+        }
+        if (dailyDemandChart) {
+            dailyDemandChart.destroy();
+            dailyDemandChart = null;
+        }
+        document.getElementById('totalSales').innerHTML = '<p>Немає даних для вибраного року</p>';
+        return;
+    }
+    const colors = getProductColors(productData, filteredMonths);
+    const months = filteredMonths.map(m => `${m.month} ${m.year}`);
     const productSizes = getProductSizes(productData);
     let salesDatasets = [];
     if (chartType === 'byColor') {
         salesDatasets = colors.map(color => {
-            const data = productData.months.map(month => {
+            const data = filteredMonths.map(month => {
                 return month.colors[color] ? month.colors[color].reduce((sum, item) => sum + item.quantity, 0) : 0;
             });
             return {
@@ -307,11 +489,12 @@ function updateChart() {
                 categoryPercentage: 0.9
             };
         });
-        salesChartTitle.textContent = `Продажі за кольором для ${productSelect} по місяцях`;
-        dailyDemandChartTitle.textContent = `Щоденний попит за кольором для ${productSelect} по місяцях`;
+        const titleSuffix = selectedYear ? ` (${selectedYear} рік)` : '';
+        salesChartTitle.textContent = `Продажі за кольорами для ${productSelect}${titleSuffix}`;
+        dailyDemandChartTitle.textContent = `Щоденний попит за кольорами для ${productSelect}${titleSuffix}`;
     } else {
         salesDatasets = productSizes.map(size => {
-            const data = productData.months.map(month => {
+            const data = filteredMonths.map(month => {
                 const colorData = month.colors[chartType];
                 const item = colorData ? colorData.find(i => i.size === size) : null;
                 return item ? item.quantity : 0;
@@ -326,11 +509,12 @@ function updateChart() {
                 categoryPercentage: 0.9
             };
         });
-        salesChartTitle.textContent = `Продажі за розмірами для кольору ${chartType} (${productSelect}) по місяцях`;
-        dailyDemandChartTitle.textContent = `Щоденний попит за розмірами для кольору ${chartType} (${productSelect}) по місяцях`;
+        const titleSuffix = selectedYear ? ` (${selectedYear} рік)` : '';
+        salesChartTitle.textContent = `Продажі за розмірами для кольору ${chartType} (${productSelect})${titleSuffix}`;
+        dailyDemandChartTitle.textContent = `Щоденний попит за розмірами для кольору ${chartType} (${productSelect})${titleSuffix}`;
     }
     // Update total sales
-    updateTotalSales(salesDatasets);
+    updateTotalSales(productData, filteredMonths, chartType, salesDatasets);
     // Update sales chart
     if (salesChart) {
         salesChart.destroy();
@@ -378,7 +562,7 @@ function updateChart() {
         }
     });
     // Update daily demand chart
-    const dailyDemandDatasets = calculateDailyDemandData(productData, chartType);
+    const dailyDemandDatasets = calculateDailyDemandData(productData, filteredMonths, chartType);
     if (dailyDemandChart) {
         dailyDemandChart.destroy();
     }
@@ -437,7 +621,7 @@ function init() {
     }
     updateProductSelect();
     updateChartTypes();
-    const productData = salesData.products[0]; // Ініціалізуємо першим продуктом
+    const productData = normalizedProducts[0]; // Ініціалізуємо першим продуктом
     if (productData) {
         updateYearSelect(productData);
         updateMonthSelect(productData);
@@ -447,7 +631,11 @@ function init() {
     updateChart();
     document.getElementById('productSelect').addEventListener('change', () => {
         updateChartTypes();
-        const productData = salesData.products.find(p => p.name === document.getElementById('productSelect').value);
+        const productData = getProductByName(document.getElementById('productSelect').value);
+        if (!productData) {
+            console.error('Product not found for selection change');
+            return;
+        }
         updateYearSelect(productData);
         updateMonthSelect(productData);
         updateColorSelect(productData);
@@ -458,19 +646,33 @@ function init() {
         updateChart();
     });
     document.getElementById('yearSelect').addEventListener('change', () => {
-        const productData = salesData.products.find(p => p.name === document.getElementById('productSelect').value);
+        const productData = getProductByName(document.getElementById('productSelect').value);
+        if (!productData) {
+            console.error('Product not found when year changed');
+            return;
+        }
         updateMonthSelect(productData);
         updateColorSelect(productData);
         updateWeeklyDemand(productData);
+        updateChart();
     });
     document.getElementById('monthSelect').addEventListener('change', () => {
-        const productData = salesData.products.find(p => p.name === document.getElementById('productSelect').value);
+        const productData = getProductByName(document.getElementById('productSelect').value);
+        if (!productData) {
+            console.error('Product not found when month changed');
+            return;
+        }
         updateColorSelect(productData);
         updateWeeklyDemand(productData);
     });
     document.getElementById('colorSelect').addEventListener('change', () => {
-        const productData = salesData.products.find(p => p.name === document.getElementById('productSelect').value);
+        const productData = getProductByName(document.getElementById('productSelect').value);
+        if (!productData) {
+            console.error('Product not found when color changed');
+            return;
+        }
         updateWeeklyDemand(productData);
+        updateChart();
     });
 }
 // Run after DOM is loaded

--- a/styles.css
+++ b/styles.css
@@ -117,6 +117,18 @@ select:focus {
     color: #6A5ACD;
     flex: 0 0 auto;
 }
+.total-sales .diff {
+    font-weight: bold;
+}
+.total-sales .diff.positive {
+    color: #2e7d32;
+}
+.total-sales .diff.negative {
+    color: #c62828;
+}
+.total-sales .diff.neutral {
+    color: #6c757d;
+}
 #weeklyDemandList ul.fade-in {
     animation: fadeIn 0.5s ease-in;
 }


### PR DESCRIPTION
## Summary
- compute year-over-year comparisons for total sales and weekly demand summaries so 2025 values show +/- deltas against 2024
- add formatting helpers and styling to render the differences in color-coded parentheses

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d1263ee0dc8333837cf985b4c3de44